### PR TITLE
add caption tag to enrollment trends table

### DIFF
--- a/after.html
+++ b/after.html
@@ -179,6 +179,7 @@
         </div>
 
         <table id="enrollment" aria-describedby="table-summary">
+          <caption class="clipped">AU Enrollment Trends</caption>
           <thead>
             <tr>
               <td style="width:6em">&nbsp;</td>


### PR DESCRIPTION
Adding a `<caption>` tag labels table for navigation via Web Item Rotor in VoiceOver.
I'd imagine it would provide similar affordances in other screen readers, in a way
that `aria-describedby` does not.